### PR TITLE
Add prd and dev groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
       directory: "/" # Location of package manifests
       schedule:
           interval: "weekly"
+      groups:
+        production-dependencies:
+          dependency-type: "production"
+        development-dependencies:
+          dependency-type: "development"


### PR DESCRIPTION
Attempting to collect updates into 1 PR per group
as described in
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups