### PR TITLE
Settings tab: style for mobile

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,12 @@
-import { App, Plugin, PluginSettingTab, Setting, TFile, Vault } from "obsidian";
+import {
+	App,
+	Plugin,
+	PluginSettingTab,
+	Setting,
+	TFile,
+	Vault,
+	Platform,
+} from "obsidian";
 import Matcher from "./matcher";
 
 interface TemplateByNoteNameSettings {
@@ -146,6 +154,7 @@ class TemplateByNoteNameSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 
 		containerEl.empty();
+
 		containerEl.createEl("h1", { text: "Template by Note Name" });
 
 		new Setting(containerEl)
@@ -194,7 +203,10 @@ class TemplateByNoteNameSettingTab extends PluginSettingTab {
 		this.plugin.settings.matchers.forEach((matcher, index) => {
 			const setting = new Setting(containerEl);
 
-			setting.controlEl.appendText("If note name");
+			if (!Platform.isMobile) {
+				setting.controlEl.appendText("If note name");
+			}
+
 			setting.setClass("template-by-note-name-matcher-row");
 			setting.addDropdown((dropdown) =>
 				dropdown
@@ -220,7 +232,9 @@ class TemplateByNoteNameSettingTab extends PluginSettingTab {
 					}),
 			);
 
-			setting.controlEl.appendText("use template");
+			if (!Platform.isMobile) {
+				setting.controlEl.appendText("use template");
+			}
 
 			setting
 				.addDropdown((dropdown) => {

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,9 @@ If your plugin does not need CSS, delete this file.
 	background-color: darkgreen !important;
 	margin-left: 20px;
 	font-weight: bold;
+	max-width: 44px;
+	min-width: 44px;
+	padding: 4px 10px !important;
 }
 
 .template-by-note-name-add-matcher-button:hover {
@@ -29,10 +32,17 @@ If your plugin does not need CSS, delete this file.
 	justify-content: flex-start;
 }
 
+.template-by-note-name-matcher-row .setting-item-control input {
+	min-width: 132px;
+}
+
 .template-by-note-name-matcher-row .setting-item-control .delete-button {
 	margin-left: auto;
 	background-color: darkred;
 	font-weight: bold;
+	max-width: 44px;
+	min-width: 44px;
+	padding: 4px 10px;
 }
 
 .template-by-note-name-matcher-row .setting-item-control .delete-button:hover {


### PR DESCRIPTION
- Does not displays sentence-like phrases within matcher rules if platform is mobile
- Ensures a useable min width for match string text input in rule rows
- Styles + and - buttons to be constant size across mobile and desktop